### PR TITLE
Fix colon in YAML descriptions

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: solana-anchor-claude-skill
-description: Use when working on Solana software, including one or more of: Solana client code using TypeScript, Rust libraries that use Solana crates, Anchor programs, including Rust program files, TypeScript tests, and Anchor.toml configuration. Designed to create minimal, reusable code without unecessary duplication.
+description: "Use when working on Solana software, including one or more of: Solana client code using TypeScript, Rust libraries that use Solana crates, Anchor programs, including Rust program files, TypeScript tests, and Anchor.toml configuration. Designed to create minimal, reusable code without unnecessary duplication."
 ---
 
 # Coding Guidelines


### PR DESCRIPTION
Unquoted description containing ": " was parsed as a YAML mapping by gray-matter, causing the string type check in the skills CLI to fail silently with "No valid skills found".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation/YAML front-matter tweak to ensure `description` is parsed as a string; no runtime code paths are modified.
> 
> **Overview**
> Fixes `SKILL.md` front-matter by quoting the `description` value (which contains `: `) so YAML/gray-matter doesn’t misinterpret it as a mapping and the skills CLI can detect the skill correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1661a3165c43876f878307f42025b9ef1afca63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->