### PR TITLE
Add Editing Quasar Programs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Solana Anchor Claude Skill
 
-A Claude Code skill for creating and editing Solana projects, including Rust/Anchor and TypeScript, with a focus on:
+A Claude Code skill for creating and editing Solana projects, including Rust/Anchor, Rust/Quasar, and TypeScript, with a focus on:
 
 - Maintainability
 - Readability
@@ -28,7 +28,7 @@ This automatically installs the skill to your Claude Code skills directory (`~/.
 
 ## Usage
 
-Once installed, the skill automatically applies when Claude Code works on Solana/Anchor projects. You can also manually invoke it with:
+Once installed, the skill automatically applies when Claude Code works on Solana programs (Anchor or Quasar) or Solana TypeScript clients. You can also manually invoke it with:
 
 ```
 /solana-anchor-claude-skill

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: solana-anchor-claude-skill
-description: "Use when working on Solana software, including one or more of: Solana client code using TypeScript, Rust libraries that use Solana crates, Anchor programs, including Rust program files, TypeScript tests, and Anchor.toml configuration. Designed to create minimal, reusable code without unnecessary duplication."
+description: "Use when working on Solana software, including one or more of: Solana client code using TypeScript, Rust libraries that use Solana crates, Anchor programs, Quasar programs, Rust program files for either framework, TypeScript tests, and Anchor.toml or Quasar.toml configuration. Designed to create minimal, reusable code without unnecessary duplication."
 ---
 
 # Coding Guidelines
@@ -367,6 +367,18 @@ pub struct InitializeProfile<'info> {
 ### System Functions
 
 - When you get the time via Clock, use `Clock::get()?;` rather than `anchor_lang::solana_program::clock`
+
+## Editing Quasar Programs
+
+Quasar is a newer Solana program framework that uses Anchor-like syntax (`#[program]`, `#[derive(Accounts)]`, `#[account]`) but with vastly better runtime performance: zero-copy account access, no_std, dense instruction discriminators, and compiled output that is roughly an order of magnitude smaller than the equivalent Anchor binary. The surface is familiar to Anchor developers; a few conveniences work differently or are not present yet. The rules below come out of the recent asset-leasing port.
+
+- **Use the same program ID as the Anchor port.** Offchain tooling derives PDAs from the program ID; matching IDs across the Anchor and Quasar binaries means clients work against either build with no changes.
+- **Account state numeric fields are Pod-wrapped.** Reading is `let value: u64 = self.field.into();` and writing is `self.field = PodU64::from(value);`. Same for `PodU32`, `PodI64`, etc. Forgetting the conversion compiles but produces wrong values.
+- **`log()` takes a static string only.** No format strings, no interpolation. If you need to log a value, either issue multiple `log()` calls with separate static strings or log the raw bytes.
+- **Account structs need explicit lifetimes.** Use `<'info>` on the struct and `&'info` / `&'info mut` on each reference field. Quasar will not infer these for you.
+- **No `realloc` constraint.** Pick the maximum size up front and use fixed-capacity inline storage like `PodString<N>` or `PodVec<T, N>`. Plan the layout before writing the state struct.
+- **No `close` constraint.** If an account needs to be closed, zero the lamports and clear the data manually inside the handler.
+- **No `CpiContext`.** SPL CPIs use the helper style on the program handle: `self.token_program.transfer(...).invoke()`. Generic CPIs use `BufCpiCall::new(...).invoke()`. Anchor's `CpiContext::new(program, accounts).invoke()` pattern does not exist here.
 
 ## Git commits
 


### PR DESCRIPTION
Capture the Quasar rules learned from porting asset-leasing. Quasar is the lower-level framework used for performance-sensitive ports of Anchor programs; most of the surface looks like Anchor but several conveniences are missing or different (no realloc, no close, no CpiContext, account state numeric fields are Pod-wrapped, log() takes static strings only, account structs need explicit lifetimes).

Use the same program ID across the Anchor and Quasar binaries so off-chain tooling that derives PDAs works against either build with no changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no runtime, build, or security-sensitive code is modified.
> 
> **Overview**
> Updates the skill docs to explicitly cover **Quasar** alongside Anchor, including refreshed `README.md`/frontmatter wording so the skill is invoked for both frameworks and their configs (e.g., `Quasar.toml`).
> 
> Adds a new **"Editing Quasar Programs"** section to `SKILL.md` documenting Quasar-specific constraints and gotchas (shared program ID with Anchor for PDA derivations, Pod-wrapped numeric fields, `log()` static-string limitation, explicit lifetimes, and lack of `realloc`/`close` constraints and `CpiContext`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63635dfa80bb456b829fd3e155c28850e5d0927c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->