### PR TITLE
Add 'fight for truth', seperate Rust and TypeScript files

### DIFF
--- a/RUST.md
+++ b/RUST.md
@@ -7,7 +7,7 @@ These guidelines apply to Anchor programs and any Rust crates that use Solana de
 - Write all code like the latest stable Anchor (currently 1.0.2 but there may be a newer version by the time you read this)
 - Use LiteSVM and Rust tests for new Anchor programs. `anchor init` uses LiteSVM by default.
 - Do not use unnecessary macros that are not needed in the latest stable Anchor
-- Don't implement instruction handlers as methods on account structs. There's no reason to tie state to functions, the function is not modifying the state (if we did like OOP, which we don't), and the functions and structs work without doing this, so there's no reason to add implement instruction handlers as methods on account structs.
+- Don't implement instruction handlers as methods on account structs. There's no reason to tie state to functions, the function is not modifying the state (if we did like OOP, which we don't), and the functions and structs work without doing this, so there's no reason to implement instruction handlers as methods on account structs.
 
 ## Anchor has silly defaults
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -37,7 +37,7 @@ Ship the complete thing. When the user asks for something, the answer is the fin
 
 ## Success Criteria
 
-- Before declaring success, declaring that work is complete, or celebrating, run the tests (`anchor test`). If the tests fail, there is more work to do. Don't stop until `anchor test` passes on the code you have made.
+- Before declaring success, declaring that work is complete, or celebrating, run the project's actual tests using the correct command for that project (for example: `anchor test` for Anchor workspaces, the project's TypeScript test command for TypeScript clients/tests, or `cargo test` for Rust crates). If the tests fail, there is more work to do. Don't stop until the relevant test command passes on the code you have made.
 - Do not write placeholder tests. Placeholder tests don't count as tests, placeholder tests passing does not achieve your task.
   - Tests that just do `assert.ok(true)` or similar are placeholder tests and do not count as tests
   - Tests that do not call the program's instruction handlers are placeholder tests and do not count as tests

--- a/SKILL.md
+++ b/SKILL.md
@@ -95,7 +95,7 @@ Use these official documentation sources:
 
 - Do not use any documentaton or tools from Project Serum, which collapsed many years ago.
 
-- Do not use yarn. Use npm. Yarn has no reason to exist and only adds unnecessary dependencies. Replace Yarn with npm everywhere you see it. pnpm is also OK.
+- Do not use yarn. Yarn has no reason to exist and only adds unnecessary dependencies and is not commonly used for new JS/TS projects in 2026. Replace Yarn with npm everywhere you see it. Use npm for new projects as it does not require additional dependencies. Keep using pnpm if the project already uses pnpm.
 
 - Do not use **Switchboard Functions** - this product is dead and no longer maintained. (Note: Switchboard oracles are still active and usable.)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -171,7 +171,7 @@ Example:
 ahash = "=0.8.6"
 ```
 
-When you remove a section, only add why to the git commit, so the file is free of information that does not apply to it's existing state.
+When you remove a section, only add why to the git commit, so the file is free of information that does not apply to its existing state.
 
 ### Working with Generated or Unfamiliar Code
 

--- a/TYPESCRIPT.md
+++ b/TYPESCRIPT.md
@@ -65,7 +65,7 @@ import assert from "node:assert";
 
 ## Thrown object handling
 
-- JavaScript allows arbitrary items - strings, array, numbers etc to be 'thrown'. However you can assume that any non-Error item that is thrown is an programmer error. Handle it like this (including the comment since most TypeScript developers don't know this):
+- JavaScript allows arbitrary items - strings, array, numbers etc to be 'thrown'. However you can assume that any non-Error item that is thrown is a programmer error. Handle it like this (including the comment since most TypeScript developers don't know this):
 
 ```ts
 // In JS it's possible to throw *anything*. A sensible programmer

--- a/TYPESCRIPT.md
+++ b/TYPESCRIPT.md
@@ -4,7 +4,7 @@ These guidelines apply to TypeScript unit tests, browser code, Solana Kit client
 
 ## General TypeScript
 
-Use `type: module` in `package.json` files.
+Use `"type": "module"` in `package.json` files.
 
 Avoid using a `tsconfig.json` unless it's needed, as we use `tsx` to run most typescript and it doesn't usually need one. If you do need a `tsconfig.json`, state why at the top of the file, and you can use the most modern version of ECMAScript/JavaScript you want - up to say 2023.
 


### PR DESCRIPTION
We've recently used this to build 2 new exchanges copying some learning from well known open source Solana exchanges, as well as cleaned up some common issues in `solana-program-examples`.

- Add a new `RUST.md` with detailed Anchor and Rust best practices
- Add a "Fight for Truth" section
- Add a terminology section to standardize Solana-specific language and discourage Ethereum terminology
- Improved guidelines for removing unnecessary code, comments, and doc-comments, and clarified when to keep or remove comments.
