### PR TITLE
Skill rename, Quasar section, Anchor 1.0 notes, and documentation style rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Solana Anchor Claude Skill
+# Solana Claude Skill
 
-A Claude Code skill for creating and editing Solana projects, including Rust/Anchor and TypeScript, with a focus on:
+A Claude Code skill for creating and editing Solana projects, including Rust/Anchor/Quasar and TypeScript, with a focus on:
 
 - Maintainability
 - Readability
 - Minimal code
-- Financial maths
+- Financial math
 - 2026 best practices
 
 > [!TIP]
-> This skill has the **most stars of any Solana Claude skill** not produced by the Solana Foundation (which inherently get more distribution) and is made by someone working in the software industry for more than 25 years, based on code used by some of the largest programs on Solana. If you find it useful, please add a GitHub star above! 🙏 
+> This skill has the **most stars of any ecosystem Solana Claude skill** and is made by someone working in the software industry for more than 25 years, based on code used by some of the largest programs on Solana. If you find it useful, please add a GitHub star above! 🙏 
 
 ## Sponsor shout out
 
@@ -22,15 +22,15 @@ Claude Code supports "skills" - reusable instruction sets that Claude automatica
 ## Installation
 
 ```bash
-npx skills add https://github.com/quicknode/solana-anchor-claude-skill
+npx skills add https://github.com/quicknode/solana-claude-skill
 ```
 
 This automatically installs the skill to your Claude Code skills directory (`~/.claude/skills/`).
 
 ## Usage
 
-Once installed, the skill automatically applies when Claude Code works on Solana/Anchor projects. You can also manually invoke it with:
+Once installed, the skill automatically applies when Claude Code works on Solana/Anchor/Quasar projects. You can also manually invoke it with:
 
 ```
-/solana-anchor-claude-skill
+/solana-claude-skill
 ```

--- a/RUST.md
+++ b/RUST.md
@@ -9,6 +9,11 @@ These guidelines apply to Anchor programs and any Rust crates that use Solana de
 - Do not use unnecessary macros that are not needed in the latest stable Anchor
 - Don't implement instruction handlers as methods on account structs. There's no reason to tie state to functions, the function is not modifying the state (if we did like OOP, which we don't), and the functions and structs work without doing this, so there's no reason to implement instruction handlers as methods on account structs.
 
+### Anchor 1.0 specifics
+
+- **`CpiContext::new()` takes a `Pubkey` directly**, not an `AccountInfo`. Use `self.token_program.key()` rather than `self.token_program.to_account_info()` when constructing a `CpiContext`.
+- **Use `transfer_checked` for all SPL token CPIs.** Plain `transfer` is deprecated. `transfer_checked` requires the mint and decimals, which you should be passing anyway.
+
 ## Anchor has silly defaults
 
 Every project will need an IDL.
@@ -99,9 +104,11 @@ Applies to any code touching money, balances, prices, shares, fees, or token amo
 - **Integers only — no floats, no fixed-point libraries.** Floats are non-deterministic across platforms (different validators could disagree on state). `fixed::types::I64F64`, `rust_decimal`, `bnum`-fixed-point and similar are also out — they add audit surface, burn compute, and hide the rounding/precision decisions you should be making explicitly. Token amounts are integers (base units), prices are ratios of integers. The system is discrete. Production Solana AMMs (Orca, Raydium, Meteora, Saber, Phoenix) all use raw `u128`. If you find yourself reaching for a decimal type, stop — the right tool is `u128` with discipline.
 - **Multiply before you divide.** `a * b / c`, not `(a / c) * b`. Division truncates; dividing first throws away precision permanently.
 - **Use `u128` (or wider) for intermediate products.** `u64 * u64` overflows at ~1.8e19. Cast both operands to `u128` _before_ multiplying, then narrow the final result with `try_into().map_err(|_| MyError::MathOverflow)?`.
+- **For price × quantity × rate, u128 may not be enough.** `price (u64) × quantity (u64) × rate (u64)` can reach ~5.4e58, which overflows u128 (~3.4e38). If your hot path multiplies three u64-scale values together, either bound your inputs tightly and document the proof, or hand-roll a U256 type (~200 lines of Newton-based arithmetic, as Uniswap V2 in Solidity and Saber in Rust do). Don't reach for a crate just for this.
 - **Round in the protocol's favour, never the user's.** Value-to-share and share-to-value conversions: user gets floor, protocol gets ceil. Otherwise you leak 1 base unit per transaction forever, and attackers will industrialise it.
 - **Validate ranges before doing the math.** Reject zero inputs, `amount > balance`, ratios that would mint zero shares. Cheap, prevents the inflation/donation attack on empty pools and other whole bug classes.
 - **Check invariants after the math, not just before.** "K must not decrease" on a swap, "total LP shares == sum of holdings", "reserves >= owed fees". Compute, then `require!()` the invariant.
+- **Assert token conservation on every instruction that moves funds.** Before returning from any instruction that transfers tokens between vaults or accounts, verify that total value in == total value out. Sum all debits and credits and `require!` they balance. A one-line conservation check catches an entire class of drain bugs before they reach mainnet.
 - **Decimals are tracked, not assumed.** USDC=6, SOL=9, SPL tokens vary. Use `transfer_checked` (carries decimals in the CPI). Reserves hold raw base units; the UI does cosmetic conversion. Never hard-code `* 10^9`.
 - **Oracle/price freshness is part of the math.** Check `last_updated_slot` and reject if older than N slots. A stale price means the calculation is wrong.
 - **Checks-effects-interactions.** Update state before the token transfer CPI, not after.
@@ -148,6 +155,16 @@ let final_a: u64 = final_a.try_into().map_err(|_| ErrorCode::MathOverflow)?;
 let final_b: u64 = final_b.try_into().map_err(|_| ErrorCode::MathOverflow)?;
 ```
 
+## Config Validation
+
+When an admin instruction accepts a configuration struct, don't just check that the fields are well-formed — check that they are financially safe. Write a `validate_config` function that rejects configurations which would make the program exploitable even if each field is individually valid:
+
+- Verify that fee rates, margins, and limits don't combine to produce impossible states (e.g. liquidation fee + protocol fee > maintenance margin means the protocol can be insolvent by design)
+- Verify that numeric bounds don't overflow the hot-path calculations that use them
+- `require!` these properties when the config is accepted, not in every handler that reads it
+
+This is the difference between "is this a valid u64" and "does this configuration make the program safe". Reject unsafe configs at init time.
+
 ## Cargo hygiene
 
 - Run `cargo clean` after finishing with a Rust project. Anchor `target/` directories accumulate fast (multi-GiB per project).
@@ -157,7 +174,77 @@ let final_b: u64 = final_b.try_into().map_err(|_| ErrorCode::MathOverflow)?;
 
 - Add `pub bump: u8` to every struct stored in PDA
 - Save the bumps inside each when the struct inside the PDA is created
+- **Include an instance discriminator in accounts that belong to a specific instance.** If your program manages multiple independent pools, markets, or vaults, store the instance's pubkey (e.g. the pool or market address) in each subordinate account and validate it on every instruction. Without this, an attacker can pass an account from one instance into an instruction for another — the types match, Anchor won't catch it, and the math silently operates on the wrong state.
 
 ## System Functions
 
 - When you get the time via Clock, use `Clock::get()?;` rather than `anchor_lang::solana_program::clock`
+
+## Editing Quasar Programs
+
+Quasar is a Solana program framework that uses Anchor-like syntax (`#[program]`, `#[derive(Accounts)]`, `#[account]`) but with better runtime performance: zero-copy account access, `no_std`, dense instruction discriminators, and compiled output roughly an order of magnitude smaller than equivalent Anchor binaries. The surface is familiar to Anchor developers, but several conveniences work differently or are absent.
+
+- **Use the same program ID as the Anchor build.** Offchain tooling derives PDAs from the program ID; matching IDs across Anchor and Quasar binaries means clients work against either build unchanged.
+- **Account state numeric fields are Pod-wrapped.** Read with `let value: u64 = self.field.into();` and write with `self.field = PodU64::from(value);`. Same for `PodU32`, `PodI64`, etc. Forgetting the conversion compiles but produces wrong values.
+- **`log()` takes a static string only.** No format strings, no interpolation. To log a value, issue multiple `log()` calls with separate static strings or log the raw bytes.
+- **Account structs need explicit lifetimes.** Use `<'info>` on the struct and `&'info` / `&'info mut` on each reference field. Quasar will not infer these.
+- **No `realloc` constraint.** Pick the maximum size up front and use fixed-capacity inline storage like `PodString<N>` or `PodVec<T, N>`. Plan the layout before writing the state struct.
+- **No `close` constraint.** To close an account, zero the lamports and clear the data manually inside the handler.
+- **No `CpiContext`.** SPL CPIs use the helper style on the program handle: `self.token_program.transfer(...).invoke()`. Generic CPIs use `BufCpiCall::new(...).invoke()`. Anchor's `CpiContext::new(program, accounts).invoke()` pattern does not exist in Quasar.
+
+### Testing Quasar programs (QuasarSVM)
+
+Quasar programs use **QuasarSVM** as the test harness — not LiteSVM. It is an in-process SVM with no validator required. Run tests with `quasar test` (or `cargo test -- --nocapture` to see CU output).
+
+Add to `[dev-dependencies]` in the program's `Cargo.toml`:
+
+```toml
+[dev-dependencies]
+quasar-svm = { git = "https://github.com/blueshift-gg/quasar-svm" }
+solana-account = "3.4.0"
+solana-address = { version = "2.2.0", features = ["decode"] }
+solana-instruction = { version = "3.2.0", features = ["bincode"] }
+solana-pubkey = "4.1.0"
+```
+
+The basic test shape:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use quasar_svm::{ExecutionStatus, QuasarSvm};
+    use solana_account::Account;
+    use solana_pubkey::Pubkey;
+
+    fn setup() -> QuasarSvm {
+        let elf = include_bytes!("../target/deploy/my_program.so");
+        QuasarSvm::new()
+            .with_program(&Pubkey::from(crate::ID), elf)
+    }
+
+    #[test]
+    fn test_initialize() {
+        let svm = setup();
+        let payer = Pubkey::new_unique();
+
+        let result = svm.process_transaction(
+            &[instruction],
+            &[(payer, Account::new(10_000_000_000, 0, &system_program))],
+        );
+
+        match result.status() {
+            ExecutionStatus::Success => {}
+            ExecutionStatus::Err(e) => panic!("failed: {e}"),
+        }
+    }
+}
+```
+
+Key differences from LiteSVM:
+- Load the program with `QuasarSvm::new().with_program(id, elf)` instead of `svm.add_program(id, bytes)`
+- Pass initial account state as `(Pubkey, Account)` tuples directly to `process_transaction` — no separate airdrop step
+- `result.status()` returns `ExecutionStatus::Success` or `ExecutionStatus::Err`, not a `Result`
+- Check CU consumption with `result.compute_units_consumed` to assert performance budgets
+- Chain multi-step tests by feeding `resulting_accounts` from one call into the next
+
+Run with `anchor build` first so the `.so` is on disk before the `include_bytes!` compiles.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: solana-anchor-claude-skill
-description: "Use when working on Solana software, including one or more of: Solana client code using TypeScript, Rust libraries that use Solana crates, Anchor programs, Quasar programs, LiteSVM tests, including Rust program files, TypeScript tests, and Anchor.toml configuration. Designed to create minimal, reusable code without unnecessary duplication."
+name: solana-claude-skill
+description: "Use when working on Solana software, including one or more of: Solana client code using TypeScript, Rust libraries that use Solana crates, Anchor programs, Quasar programs, LiteSVM tests, including Rust program files, TypeScript tests, and Anchor.toml or Quasar.toml configuration. Designed to create minimal, reusable code without unnecessary duplication."
 ---
 
 # Coding Guidelines
@@ -57,6 +57,7 @@ Use these official documentation sources:
 - **Anchor**: https://www.anchor-lang.com/docs
 - **LiteSVM**: https://www.anchor-lang.com/docs/testing/litesvm
 - **Anchor Error Codes**: https://raw.githubusercontent.com/coral-xyz/anchor/master/lang/src/error.rs
+- **Quasar**: https://quasar-lang.com/docs
 - **Solana Kite**: https://solanakite.org
 - **Solana Kit**: https://solanakit.com
 - **Agave (Solana CLI)**: https://docs.anza.xyz/ (Anza makes the Solana CLI and Agave).
@@ -116,6 +117,16 @@ Every project must have a `README.md` file in the project root that includes:
 - **Usage**: Basic usage examples or deployment instructions if applicable
 
 Keep the README focused and practical. Avoid generic boilerplate - write documentation that would actually help someone understand and work with this specific project.
+
+### Documentation style
+
+- **No numbered headings.** Headings are words only — no `## 1. Overview` or `### 3.6 Liquidation`. Numbered headings break when a section is inserted or removed.
+- **No preview paragraphs.** Don't open a README or section with "the sections below cover X, Y, and Z" — the headings already do that.
+- **Integrate per-instruction reference into lifecycle prose.** Walk through the program's flow and inline each handler's mechanics (signers, accounts, token movements, errors) at the point it's first called. Don't keep a separate flat "Instruction Reference" section.
+- **Bold canonical terms on first use**, plain everywhere after — like a textbook.
+- **No ASCII art, no Mermaid diagrams, no markdown tables.** Use headings, nested bullet lists, or prose. Tables don't render well on chat surfaces.
+- **No em-dashes.** Use a regular dash or rewrite the sentence. Em-dashes are an LLM-output tell. This applies to READMEs, code comments, commit messages, and doc strings.
+- **Don't say "worked example" or "worked scenario".** Just "Example", "Scenario", or "Walkthrough".
 
 ## Writing About Financial Software
 

--- a/TYPESCRIPT.md
+++ b/TYPESCRIPT.md
@@ -25,6 +25,7 @@ Favor `async`/`await` and `try/catch` over `.then()` or `.catch()` or using call
 ## Solana-Specific TypeScript
 
 - Don't make new `@solana/web3.js` version 1 code. Do not make new code using `@coral-xyz/anchor` package. Don't replace Solana Kit with web3.js version 1 code. web3.js version 1 is legacy and should be eventually removed. Solana Kit used to be called web3.js version 2. Use Solana Kit, preferably via Solana Kite.
+- **Anchor 1.0 TypeScript package is `@anchor-lang/core`**, not `@coral-xyz/anchor`. New TypeScript code that interacts with Anchor programs imports from `@anchor-lang/core`. The Rust crate is still `anchor-lang`.
 - Use Kite's `connection.getPDAAndBump()` to turn seeds into PDAs and bumps
 - There is no need to use offsets that you set to decode Solana account data - either download an npm package for the program like `@solana-program/token` for the token program or make one using Codama.
 - In Solana Kit, you make instructions by making TS clients from IDLs using Codama. You can easily make Codama clients for installed IDLs using:
@@ -48,6 +49,52 @@ const signature = getBase58Decoder().decode(signatureBytes);
 ```
 
 Yes, `bs58` and `@solana/codecs` packages have different concepts of 'encode' and 'decode'.
+
+## Compute Budget and Priority Fees
+
+Production transactions need a compute budget instruction and usually a priority fee. Add both at the start of your instruction array using `@solana-program/compute-budget`:
+
+```typescript
+import {
+  getSetComputeUnitLimitInstruction,
+  getSetComputeUnitPriceInstruction,
+} from "@solana-program/compute-budget";
+
+const instructions = [
+  getSetComputeUnitLimitInstruction({ units: 200_000 }),
+  getSetComputeUnitPriceInstruction({ microLamports: 1_000 }),
+  // ...your program instructions
+];
+```
+
+- Set the compute unit limit to a value measured from simulation — don't guess. Over-budgeting wastes fee payer SOL; under-budgeting causes `ComputationalBudgetExceeded`.
+- Set the priority fee (`microLamports`) based on current network conditions. For production code, fetch the recent prioritization fees via `getRecentPrioritizationFees` and use a percentile of recent fees for the accounts your transaction touches.
+- Both instructions must come **before** your program instructions in the array.
+
+## Parsing Transaction Errors
+
+When a transaction fails, Solana returns logs that contain the Anchor error code. Parse them to surface a useful error rather than a raw hex string.
+
+```typescript
+import { isSolanaError, SOLANA_ERROR__TRANSACTION_ERROR__INSTRUCTION_ERROR } from "@solana/errors";
+
+try {
+  await sendAndConfirmTransaction(transaction);
+} catch (thrownObject) {
+  const error = ensureError(thrownObject);
+  if (isSolanaError(error, SOLANA_ERROR__TRANSACTION_ERROR__INSTRUCTION_ERROR)) {
+    // error.context.logs contains the program logs with the Anchor error code
+    const logs = error.context.logs ?? [];
+    const anchorError = logs.find((log) => log.includes("AnchorError"));
+    console.error("Anchor error:", anchorError ?? error.message);
+  }
+  throw error;
+}
+```
+
+- Always check `error.context.logs` first — the Anchor error message and code are in the logs, not the top-level error object.
+- Anchor error codes are documented at `https://raw.githubusercontent.com/coral-xyz/anchor/master/lang/src/error.rs` (linked in SKILL.md Documentation Sources).
+- For Kite-based code, `connection.sendTransactionFromInstructions` surfaces the same logs on failure via the thrown error.
 
 ## Unit Tests
 


### PR DESCRIPTION
Single squashed commit consolidating the skill rename with content absorbed from PRs #8, #9, #10, plus five additional gaps filled in.

## Skill rename
- Rename all `solana-anchor-claude-skill` references to `solana-claude-skill` in `README.md` and `SKILL.md` frontmatter
- Fix "Financial maths" → "Financial math", update star blurb wording

## Documentation style rules (`SKILL.md`) — from PR #8
Adds a **Documentation style** sub-section under Project Documentation:
- No numbered headings
- No preview paragraphs ("the sections below cover…")
- Integrate per-instruction reference into lifecycle prose
- Bold canonical terms on first use
- No ASCII art, no Mermaid diagrams, no markdown tables
- No em-dashes anywhere (READMEs, comments, commit messages)
- No "worked example" / "worked scenario" wording

## Quasar (`RUST.md`) — from PR #9 + gaps #2 and #3
**Editing Quasar Programs section** covering the differences from Anchor:
- Share the program ID with the Anchor build so PDA derivations work against either binary
- Pod-wrapped numeric fields (`PodU64`, `PodU32`, etc.)
- `log()` accepts static strings only
- Account structs need explicit `<'info>` lifetimes
- No `realloc`, no `close`, no `CpiContext`

**QuasarSVM testing section** (Quasar uses its own harness, not LiteSVM):
- `quasar-svm` crate setup and `Cargo.toml` dev-dependencies
- Basic test shape with `QuasarSvm::new().with_program(...)` and `process_transaction`
- Key differences from LiteSVM (no airdrop step, `ExecutionStatus`, CU consumption via `result.compute_units_consumed`)
- Run with `quasar test`

## Anchor 1.0 notes — from PR #10
- **`RUST.md`**: `CpiContext::new()` takes a `Pubkey` directly in Anchor 1.0, not an `AccountInfo`
- **`TYPESCRIPT.md`**: `@anchor-lang/core` is the Anchor 1.0 TypeScript package (not `@coral-xyz/anchor`)

## Quasar docs link (`SKILL.md`) — gap #2
- Added `https://quasar-lang.com/docs` to Documentation Sources
- Added `Quasar.toml` to the frontmatter `description` trigger list

## Compute budget and priority fees (`TYPESCRIPT.md`) — gap #4
New **Compute Budget and Priority Fees** section:
- `getSetComputeUnitLimitInstruction` and `getSetComputeUnitPriceInstruction` from `@solana-program/compute-budget`
- Guidance on measuring CU limits via simulation and fetching priority fees from `getRecentPrioritizationFees`
- Both instructions must precede program instructions in the array

## Parsing transaction errors (`TYPESCRIPT.md`) — gap #5
New **Parsing Transaction Errors** section:
- Use `isSolanaError` + `SOLANA_ERROR__TRANSACTION_ERROR__INSTRUCTION_ERROR` to detect instruction failures
- Anchor error code and message live in `error.context.logs`, not the top-level error object
- Works the same way with Kite's `sendTransactionFromInstructions`

## PRs superseded
PRs #8, #9, and #10 are now closed — all their unique content is captured here.