### PR TITLE
Fix broken "Anchor has silly defaults" section in ANCHOR.md

### DIFF
--- a/ANCHOR.md
+++ b/ANCHOR.md
@@ -15,11 +15,15 @@ Anchor-specific rules. Read these alongside the general rules in [SKILL.md](SKIL
 
 ## Anchor has silly defaults
 
-Every project will need an IDL, and al,ost every project will use tokens, so ensure that features are correct...
+Every project will need an IDL, and almost every project will use tokens, so ensure the features and dependencies are correct (insert whatever versions are applicable):
 
 ```toml
 [features]
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
+
+[dependencies]
+anchor-spl = "1.0.2"
+```
 
 ## Token program compatibility
 


### PR DESCRIPTION
## Why

The `## Anchor has silly defaults` section in `ANCHOR.md` (currently on `main`) is broken:

1. The ` ```toml ` code fence is **never closed**, so everything from there down to the next fence (the Rust example) renders as one giant code block.
2. The `anchor-spl` dependency snippet the prose introduces ("almost every project will use tokens") was **dropped**.
3. Typo: **"al,ost"** → "almost".

This slipped into `main` between the edit that reworded the intro and the merge of #19, so my earlier fix (pushed to the #19 branch after it had already merged) never reached `main`.

## What

Closes the `toml` fence, restores the `anchor-spl` dependency alongside the `idl-build` feature, and fixes the typo. Code fences in the file are balanced again (even count).

```toml
[features]
idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]

[dependencies]
anchor-spl = "1.0.2"
```

https://claude.ai/code/session_01CfCCGCXne6eViGamZwy7ot

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfCCGCXne6eViGamZwy7ot)_