### PR TITLE
Add account-binding, vault-authority, and test-integrity rules; environment setup guide

### DIFF
--- a/ANCHOR.md
+++ b/ANCHOR.md
@@ -166,7 +166,9 @@ fn test_initialize() {
 }
 ```
 
-Before the program binary exists, run `anchor build` so `target/deploy/<name>.so` is on disk; the test loads it via `include_bytes!`.
+Before the program binary exists, run `anchor build` so `target/deploy/<name>.so` is on disk; the test loads it via `include_bytes!`. Rebuild after every program change: the binary is embedded at test-compile time, so a stale `.so` silently tests old code.
+
+**Tests must live under `programs/<name>/tests/`** (a cargo target of the program crate). A `tests/` directory at the Anchor project root is not part of any cargo package - `cargo test` will report success while compiling and running nothing. If a suite "passes" suspiciously fast, check the test count in the output, not just the exit code.
 
 ### Two scaffold fixes to apply immediately after `anchor init`
 

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -22,7 +22,30 @@ tar -xjf /tmp/platform-tools.tar.bz2 -C ~/.cache/solana/${PT_VERSION}/platform-t
 
 Different tools pin different platform-tools versions (the Quasar CLI pins its own); repeat the download for each version requested in error messages.
 
-## Anchor projects without the anchor CLI
+## Anchor CLI
+
+Install from crates.io (a long compile, roughly ten minutes):
+
+```bash
+cargo install anchor-cli --locked
+```
+
+`anchor test` reads the wallet path from `Anchor.toml` (`~/.config/solana/id.json` by default), so create a throwaway keypair once per container:
+
+```bash
+solana-keygen new --no-bip39-passphrase -s -o ~/.config/solana/id.json
+```
+
+In an existing repository the original program keypairs are usually not committed, so `anchor build` fails its program-ID check against the freshly generated keypair. Do NOT run `anchor keys sync` (it would change the program IDs, which this skill forbids); build with the check skipped, and test against the in-process SVM with no validator and no deploy:
+
+```bash
+anchor build --ignore-keys
+anchor test --skip-local-validator --skip-deploy
+```
+
+(Verified: this runs the project's `test = "cargo test"` LiteSVM suite. Without `--skip-local-validator` anchor tries to spawn a `surfpool` validator; without `--skip-deploy` it tries to deploy to `localhost:8899`.)
+
+### Without the anchor CLI
 
 `anchor build` and `anchor test` are wrappers. If the anchor CLI is not installed, the equivalent is:
 

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -1,0 +1,54 @@
+# Environment Setup (CI and remote execution)
+
+How to get a working Solana toolchain in a fresh Linux container (CI runners, Claude Code on the web, devcontainers). Verified June 2026 against `quicknode/solana-program-examples`.
+
+## Agave (Solana CLI) and cargo-build-sbf
+
+```bash
+curl -sSfL https://release.anza.xyz/stable/install -o /tmp/solana-install.sh
+sh /tmp/solana-install.sh
+export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
+```
+
+`cargo build-sbf` downloads its platform-tools toolchain on first use. In environments with a TLS-intercepting proxy this download fails with `invalid peer certificate: UnknownIssuer`, because `cargo-build-sbf` uses its own certificate store rather than the system's. Work around it by downloading with `curl` (which trusts the system store) and placing the archive where `cargo-build-sbf` caches it:
+
+```bash
+# Match the version cargo-build-sbf asks for in its error message (vX.YY).
+PT_VERSION=v1.53
+curl -sSfL "https://github.com/anza-xyz/platform-tools/releases/download/${PT_VERSION}/platform-tools-linux-x86_64.tar.bz2" -o /tmp/platform-tools.tar.bz2
+mkdir -p ~/.cache/solana/${PT_VERSION}/platform-tools
+tar -xjf /tmp/platform-tools.tar.bz2 -C ~/.cache/solana/${PT_VERSION}/platform-tools
+```
+
+Different tools pin different platform-tools versions (the Quasar CLI pins its own); repeat the download for each version requested in error messages.
+
+## Anchor projects without the anchor CLI
+
+`anchor build` and `anchor test` are wrappers. If the anchor CLI is not installed, the equivalent is:
+
+```bash
+cargo build-sbf   # produces target/deploy/<name>.so
+cargo test        # runs the LiteSVM tests, which include_bytes! the .so
+```
+
+Always rebuild the `.so` after changing program code, before re-running tests: the tests embed the binary at compile time via `include_bytes!`, so a stale `.so` silently tests old code.
+
+## Quasar CLI
+
+Quasar installs from git, not crates.io. Pin the rev your project's CI pins (revs move and regress):
+
+```bash
+git clone https://github.com/blueshift-gg/quasar /tmp/quasar
+cd /tmp/quasar && git checkout <pinned-rev>
+cargo install --path cli --locked
+```
+
+Then per project: `quasar build` (also regenerates the `target/client/rust/<name>-client` crate the tests import), `quasar test`. The CLI shells out to `cargo build-sbf --tools-version vX.YY`, so the platform-tools workaround above may be needed for that version too.
+
+## Disk hygiene
+
+Each Anchor build target is 1-2 GiB. Run `cargo clean` (and `quasar clean`) per project after its tests pass, especially when building many examples in one session.
+
+## Repository session hooks
+
+For repositories used with Claude Code on the web, put the steps above in a SessionStart hook or setup script so every fresh container gets a working toolchain without manual intervention. See https://code.claude.com/docs/en/claude-code-on-the-web for environment configuration.

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -35,11 +35,11 @@ Always rebuild the `.so` after changing program code, before re-running tests: t
 
 ## Quasar CLI
 
-Quasar installs from git, not crates.io. Pin the rev your project's CI pins (revs move and regress):
+Quasar installs from git, not crates.io. Pin the exact commit your project's CI pins (branch tips move and regress):
 
 ```bash
 git clone https://github.com/blueshift-gg/quasar /tmp/quasar
-cd /tmp/quasar && git checkout <pinned-rev>
+cd /tmp/quasar && git checkout <pinned-commit>
 cargo install --path cli --locked
 ```
 

--- a/QUASAR.md
+++ b/QUASAR.md
@@ -178,6 +178,7 @@ Key differences from LiteSVM:
 - Assert outcomes with `result.assert_success()`, or `assert!(result.is_ok(), "failed: {:?}", result.raw_result)` for a custom message
 - Read post-instruction account state with `result.account(&pubkey)`
 - Check CU consumption with `result.compute_units_consumed` to assert performance budgets
+- Warp the clock with `svm.warp_to_timestamp(...)` to test time-window logic on both sides of every deadline boundary
 - Well-known IDs are re-exported: `quasar_svm::system_program::ID`, `quasar_svm::SPL_TOKEN_PROGRAM_ID`, and sysvar IDs under `quasar_svm::solana_sdk_ids`
 
 Build the program so its `.so` is on disk at `target/deploy/<name>.so` before the `include_bytes!` compiles. The generated client crate under `target/client/rust/` is produced by the same build (per `[clients]` in `Quasar.toml`).

--- a/RUST.md
+++ b/RUST.md
@@ -61,6 +61,7 @@ Applies to any code touching money, balances, prices, shares, fees, or token amo
 
 ### Escrows, Vaults, and Escape Hatches
 
+- **Every vault stores who may withdraw, and every withdraw verifies it.** A vault whose PDA signs for any caller is an open drain: if the only signer in the withdraw instruction is the fee payer and the recipient is client-supplied, anyone can withdraw anything. Record the depositor/authority when assets enter, `require!` it (against a `Signer`) when they leave. "The README admits there is no authority" does not make the program acceptable as a reference.
 - **Every escrow needs a cancel/withdraw instruction.** An escrow with no cancel locks abandoned offers forever — funds become unrecoverable when the counterparty disappears. The cancel must be callable by the maker (and only the maker) at any time before the trade settles.
 - **Don't lazily create an account the wrong party would pay rent for.** Common bug: the taker's instruction lazily creates the maker's destination ATA (e.g. via Anchor's `init_if_needed`), so the taker pays the maker's rent. Either require the maker to pre-create their ATA or pass the rent payer explicitly.
 - **Close accounts to whoever paid their rent.** The mirror image of the bullet above: when the taker settles an offer, the offer account and vault rent were paid by the maker, so `close = maker` — not `close = taker`, and never a caller-chosen unchecked account. When closing manually, move *all* lamports; leaving `minimum_balance` behind strands it forever at a PDA nobody can sign for.
@@ -100,6 +101,18 @@ If a handler accepts an offchain signature (ed25519, secp256k1 "sign in with Eth
 - Increment the stored nonce after each successful use, so a signature authorizes exactly one execution.
 - A signature over an arbitrary 32-byte value the client provides authorizes nothing in particular and everything in practice: any old signature can be replayed forever, for any amount, to any destination.
 - The signature check supplements the Solana-side authority check, it does not replace it. Keep the `Signer` + stored-authority comparison too.
+
+## Account Binding
+
+Framework type checks (Anchor `Account<T>`, Quasar `Account<T>`) only verify owner and discriminator. They do NOT link accounts to each other. Every account in a constraint struct must be bound to something:
+
+- State accounts: `seeds` / `address` derivation, or `has_one` from another bound account.
+- Vaults and ATAs: `has_one` from the state account that recorded them, or `associated_token::*` constraints.
+- Per-user records: seeds that include the signer's key, so user A cannot pass user B's record with their own token account.
+- Mints a state account stores (`usdc_mint`, `asset_mint_a`, ...): `has_one` in EVERY instruction that reads balances denominated in them. An unbound mint lets a caller substitute a junk mint whose vault is empty and skew any NAV/share calculation.
+- Stored program addresses (swap router, oracle program): either enforce them where the CPI happens or delete the field. A stored-but-never-checked address is worse than none: readers assume it is enforced.
+
+An account with no constraint and no handler-side check is a finding, not a style issue. When a program ships in multiple frameworks, port the FULL constraint set: a twin variant missing one `has_one` or one authority comparison is a security bug, not a porting shortcut.
 
 ## Config Validation
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -38,6 +38,8 @@ Ship the complete thing. When the user asks for something, the answer is the fin
 ## Success Criteria
 
 - Before declaring success, declaring that work is complete, or celebrating, run the project's actual tests using the correct command for that project (for example: `anchor test` for Anchor workspaces, the project's TypeScript test command for TypeScript clients/tests, or `cargo test` for Rust crates). If the tests fail, there is more work to do. Don't stop until the relevant test command passes on the code you have made.
+- Create all program state through the program's own instruction handlers in tests. Injecting pre-fabricated accounts (hand-built account data passed straight into the SVM) hides missing init instructions and missing constraints - a program can pass every test while being unusable onchain. Pre-fabricated accounts are only acceptable for accounts a foreign program would have created (an oracle's price account, a mainnet-dumped fixture).
+- Tests that use a zero or degenerate value for a parameter (e.g. `duration: 0`) test only the boundary where opposite comparisons coincide. Use nonzero, asymmetric values and test both sides of every boundary.
 - Do not write placeholder tests. Placeholder tests don't count as tests, placeholder tests passing does not achieve your task.
   - Tests that just do `assert.ok(true)` or similar are placeholder tests and do not count as tests
   - Tests that do not call the program's instruction handlers are placeholder tests and do not count as tests
@@ -156,6 +158,8 @@ Remove:
 - Comments that simply repeat what the code is doing, or the name of a variable, and do not add further insight.
 - Repeated code that should be turned into a named function.
 - Unused imports, unused constants, unused files, and comments that no longer apply.
+
+Before deleting "stale" scaffolding, confirm it is actually dead: grep the CI workflows (`.github/workflows/`) and package scripts for references. Test files and package.json scripts that look like leftovers are sometimes exactly what CI runs.
 - Doc-comments whose first line just paraphrases the identifier. `/// Pool authority PDA.` above `pub pool_authority` is noise. Either explain something the name doesn't (seed derivation, mutability rationale, type-choice reason, an invariant the reader can't see from the type) or delete the line.
 
 Don't remove existing comments unless they are no longer useful or accurate.
@@ -256,6 +260,8 @@ The rules above apply to every file in the project. In addition, read the file t
 - **Rust — Quasar** (`.rs` files using `quasar_lang`/`quasar_spl`): see [QUASAR.md](QUASAR.md), plus RUST.md for the shared rules
 
 If a task touches more than one, read each.
+
+For setting up a Solana toolchain in CI or a fresh remote container (Agave, platform-tools behind TLS-intercepting proxies, the Quasar CLI, building Anchor projects without the anchor CLI): see [ENVIRONMENT.md](ENVIRONMENT.md).
 
 ## Git commits
 


### PR DESCRIPTION
Additions distilled from the June 2026 audit-and-fix pass over `quicknode/solana-program-examples` (see the companion PR there). Every rule below corresponds to a bug class that actually shipped in that repo.

## RUST.md

- **New "Account Binding" section.** Framework type checks (Anchor `Account<T>`, Quasar `Account<T>`) verify owner and discriminator only - they do not link accounts to each other. Every account in a constraint struct needs `seeds`/`has_one`/`address` or a handler-side check; stored-but-never-checked addresses (a `swap_router` field nobody reads) are worse than no field; and when a program ships in multiple frameworks, the twin must port the FULL constraint set. Source bugs: the token-fundraiser quasar variant's drainable refund, vault-strategy's unbound mints, escrow quasar's unvalidated mints/vault.
- **New vault rule:** every vault stores who may withdraw and verifies it against a `Signer`. A PDA that signs for any caller is an open drain (source: cnft-vault, which shipped with a README admitting it).

## SKILL.md

- Tests must create program state through the program's own instruction handlers - injecting pre-fabricated accounts hides missing init instructions and missing constraints (the token-fundraiser quasar program passed its tests while being unusable onchain because no instruction ever created a Contributor account).
- Degenerate parameter values hide inverted comparisons: `duration: 0` makes `elapsed < duration` and `duration <= elapsed` agree at the only point tested. Use nonzero values and test both sides of every boundary (source: token-fundraiser's inverted contribution and refund windows).
- Before deleting "stale" scaffolding, grep the CI workflows - the audit flagged the native/pinocchio mocha test scaffolding as dead, but CI runs it via `pnpm build-and-test`.

## ANCHOR.md

- Rebuild the `.so` before re-running tests (`include_bytes!` embeds it at test-compile time).
- Tests must live under `programs/<name>/tests/`; a `tests/` directory at the Anchor project root is compiled by nothing, and `cargo test` reports success while running zero tests (source: vault-strategy's entire suite was orphaned this way).

## QUASAR.md

- QuasarSVM clock warping via `warp_to_timestamp` for deadline tests.

## ENVIRONMENT.md (new)

Verified setup for CI / remote containers: Agave install, the platform-tools download workaround for TLS-intercepting proxies (`cargo-build-sbf` uses its own cert store and fails with `UnknownIssuer`; curl into `~/.cache/solana/<ver>/platform-tools`), building Anchor projects without the anchor CLI (`cargo build-sbf` + `cargo test`), installing the Quasar CLI from a pinned git rev, and per-project `cargo clean` discipline.

https://claude.ai/code/session_01VPj6WLMxD5KL6NwvUvuz1K

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPj6WLMxD5KL6NwvUvuz1K)_