### PR TITLE
Add SUMMARIZING-PROGRAMS.md: rules for explaining Solana programs

### DIFF
--- a/SUMMARIZING-PROGRAMS.md
+++ b/SUMMARIZING-PROGRAMS.md
@@ -11,7 +11,7 @@ explanation-specific guidance not covered there.
 ## Explain through people and motivations
 
 - **Cast the walkthrough with named people, each with a concrete motive.** A
-  protocol becomes legible when you follow real actors doing real things.
+  program becomes legible when you follow real actors doing real things.
 - **Naming convention.** End *users* take names from the start of the alphabet —
   **Alice, Bob, Carol, Dave** — and are ordinary users, never Solana developers.
   *Admins / operators* take a name from later in the alphabet — **Maria**, or

--- a/SUMMARIZING-PROGRAMS.md
+++ b/SUMMARIZING-PROGRAMS.md
@@ -3,18 +3,10 @@
 Rules for explaining a Solana program clearly and truthfully — in a README, a
 walkthrough, a video script, or an answer.
 
-**These build on [SKILL.md](SKILL.md), which already governs the shared rules** and
-apply whenever you explain a program, not just when you write one:
-
-- *Fight for Truth* — grep before naming any identifier; describe what **is**, not
-  what was.
-- *Terminology* — Solana, not Ethereum ("programs" not "smart contracts",
-  "transaction fees" not "gas").
-- *Writing About Financial Software* — one name per role; describe custody
-  precisely instead of saying "non-custodial"/"trustless"; name the actual
-  instruction handlers in lifecycle prose.
-
-This file adds only the explanation-specific guidance not covered there.
+**These build on [SKILL.md](SKILL.md)** and apply whenever you explain a program,
+not only when you write one — in particular its *Fight for Truth*, *Terminology*,
+and *Writing About Financial Software* sections. This file adds only the
+explanation-specific guidance not covered there.
 
 ## Explain through people and motivations
 

--- a/SUMMARIZING-PROGRAMS.md
+++ b/SUMMARIZING-PROGRAMS.md
@@ -1,84 +1,87 @@
 # Summarizing Solana Programs
 
 Rules for explaining a Solana program clearly and truthfully — in a README, a
-walkthrough, a video script, or an answer. Derived from explaining a
-Kamino/Solend-style lending program end to end.
+walkthrough, a video script, or an answer.
 
-## Ground everything in the code
+**These build on [SKILL.md](SKILL.md), which already governs the shared rules** and
+apply whenever you explain a program, not just when you write one:
 
-- **Name only real identifiers.** Every handler, account, struct, and field you
-  name must exist in the source — grep before you write it. "I'm pretty sure
-  that's the name" is not good enough. A wrong name is worse than no name.
-- **Walk the lifecycle by handler.** Map each step a user takes to the actual
-  instruction handler and the key accounts it touches (e.g. "Alice calls
-  `deposit_reserve_liquidity`; it moves USDC into the reserve's `liquidity_vault`
-  and mints her share tokens"). Plain-English mechanics with no handler names
-  leave the reader unable to connect the story to the program.
-- **Get the account hierarchy right.** Spell out what owns what (market →
-  reserves → vault + share mint; obligations; per-obligation collateral vaults)
-  rather than hand-waving "the program stores it."
+- *Fight for Truth* — grep before naming any identifier; describe what **is**, not
+  what was.
+- *Terminology* — Solana, not Ethereum ("programs" not "smart contracts",
+  "transaction fees" not "gas").
+- *Writing About Financial Software* — one name per role; describe custody
+  precisely instead of saying "non-custodial"/"trustless"; name the actual
+  instruction handlers in lifecycle prose.
 
-## Use the right words
-
-- **Solana terminology, not Ethereum.** "Programs" not "smart contracts",
-  "transaction fees" not "gas". No mempools. Don't explain Solana by analogy to
-  chains the reader may not care about.
-- **Cut needless jargon.** If a plain phrase works, use it. Drop terms like
-  "money market" or "loan officer" when "lenders earn yield, borrowers borrow
-  against assets" says it more clearly.
-- **One name per role, enforced throughout.** Pick a single term for each party
-  (lender/borrower/liquidator/owner) and never switch mid-explanation.
-- **Describe what is, not what was.** Document current behavior, not history. No
-  "no longer uses X" or "previously did Y" in a summary.
+This file adds only the explanation-specific guidance not covered there.
 
 ## Explain through people and motivations
 
-- **Give each actor a name and a concrete reason to act.** "Alice wants yield on
-  idle USDC"; "Bob won't sell his SpaceX, so he borrows against it"; "Dave
-  liquidates for the discount." Personas make a protocol legible.
-- **Every actor needs a motivation — including the operator.** If the party who
-  runs the protocol has no way to make money, the economic model is incomplete;
-  say how they earn (e.g. the reserve-factor spread) or flag that they don't.
-- **Show opposing cases when the program is symmetric.** A long that wins and a
-  short that gets liquidated teaches more than one happy path.
+- **Cast the walkthrough with named people, each with a concrete motive.** A
+  protocol becomes legible when you follow real actors doing real things.
+- **Naming convention.** End *users* take names from the start of the alphabet —
+  **Alice, Bob, Carol, Dave** — and are ordinary users, never Solana developers.
+  *Admins / operators* take a name from later in the alphabet — **Maria**, or
+  another late letter.
+- **Every actor needs a motivation — including the operator.** If a participant
+  has no reason to take part, the explanation (and probably the program) is
+  incomplete. A canonical lending cast:
+  - **Alice** wants to earn yield on her USDC.
+  - **Bob** wants to stay long NVIDIA, so he borrows USDC against his NVDAx
+    instead of selling it.
+  - **Carol** wants to short SpaceX, so she borrows SPCXx and sells it.
+  - **Dave** liquidates unhealthy positions for the discount.
+  - **Maria** runs the market and earns the interest spread (the reserve factor).
+- **Show opposing cases when the program is symmetric** (a long that wins and a
+  short that gets liquidated teaches more than one happy path).
 
-## Be honest about mechanism and incentives
+## Use real, recognizable assets
 
-- **Explain incentives correctly, and correct common misconceptions.** Don't let
-  a plausible-but-wrong mental model stand. Example: liquidation is not a "crank
-  fee" — the liquidator is a principal who repays debt from their own pocket and
-  takes the borrower's collateral at a discount; the program can't sell
-  collateral itself, so it pays outsiders to show up.
+- **Only reference tokens that actually exist** — verify before naming one.
+- **Prefer well-known real-world assets** the audience already understands, and
+  gloss each on first use: **USDC** (US dollars), **NVDAx** (NVIDIA stock),
+  **SPCXx** (SpaceX stock).
+- **No memecoins**, and **avoid SOL** wherever possible — its price is
+  meaningless to most people, whereas a dollar or a familiar stock is not.
+- **Numbers are real and current, or clearly hypothetical.** Cite a price you
+  state (real token, today's value, with a source); label any invented or future
+  figure as illustrative. Keep token math concrete with base units and a worked
+  example ("100 SPCXx at \$170 = \$17,000 collateral; 75% LTV ⇒ borrow up to
+  \$12,750").
+
+## Get the mechanism and incentives right
+
+- **Explain incentives correctly, and correct plausible-but-wrong mental
+  models.** Example: liquidation is not a "crank fee" — the liquidator is a
+  principal who repays debt from their own pocket and takes the borrower's
+  collateral at a discount; the program can't sell collateral itself, so it pays
+  outsiders to show up.
 - **Contrast onchain vs offchain on what actually differs:** collateral instead
   of credit, rules-as-deployed-bytecode, algorithmic (utilization-based) rates,
   permissionless liquidation, oracle dependence, and the finality of bugs.
-
-## Numbers and external facts
-
-- **Real, current, cited — or clearly hypothetical.** If you cite a token or a
-  price, verify it's real and current and cite the source. Mark any invented or
-  future figure as illustrative; never present it as fact.
-- **Keep token math concrete.** Use base units, decimals, and a worked example
-  ("100 SPCXx at $170 = $17,000 collateral; 75% LTV ⇒ borrow up to $12,750")
-  rather than vague proportions.
+- **Get the account hierarchy right** — say what owns what (market → reserves →
+  vault + share mint; obligations; per-obligation collateral vaults) rather than
+  hand-waving "the program stores it."
 
 ## Name peers, kept current
 
-- Reference real comparable programs (e.g. Kamino Lend, MarginFi, Save) and use
-  **current** names (Save, not Solend). Don't cite dead, hacked, or irrelevant
-  projects, and don't reach to other ecosystems for the comparison.
+Reference real comparable programs (e.g. **Kamino Lend**, **MarginFi**, **Save**)
+and use **current** names (Save, not Solend). Don't cite dead, hacked, or
+irrelevant projects, and don't reach to other ecosystems for the comparison.
 
-## Scope, custody, and disclaimers
+## Push back on an incomplete program — don't disclaim it
 
-- **State simplifications plainly.** Distinguish the example from production: a
-  test oracle vs a real Switchboard/Pyth feed, one market vs many, no fee tier,
-  no audit. Don't let a reader mistake a teaching example for production-ready.
-- **Describe custody precisely; avoid loaded words.** Don't claim "non-custodial"
-  or "trustless" loosely. Say what's true: funds sit in program-owned vault PDAs,
-  the owner can change risk params and collect fees but has no path to user
-  funds, and the deployed rules can't be bypassed.
+- **If a program isn't production-ready, fix it, don't paper over it.** When a
+  feature is missing or a participant has no incentive to take part (e.g. the
+  market operator earns nothing), say so and offer to add it — a disclaimer is
+  not a substitute for a working design.
+- **Deliberate test-only scaffolding is different** and should simply be labelled
+  as such — e.g. a mock price account standing in for a real Switchboard/Pyth
+  feed in tests. Distinguish "missing functionality" (fix it) from "test
+  stand-in" (document it).
 
 ## Shape
 
-- **Lead with the outcome**, then support it. Respect a length/time budget, cut
-  anything that doesn't earn its place, and match the depth to the audience.
+Lead with the outcome, then support it. Respect a length or time budget, cut
+anything that doesn't earn its place, and match the depth to the audience.

--- a/SUMMARIZING-PROGRAMS.md
+++ b/SUMMARIZING-PROGRAMS.md
@@ -1,0 +1,84 @@
+# Summarizing Solana Programs
+
+Rules for explaining a Solana program clearly and truthfully — in a README, a
+walkthrough, a video script, or an answer. Derived from explaining a
+Kamino/Solend-style lending program end to end.
+
+## Ground everything in the code
+
+- **Name only real identifiers.** Every handler, account, struct, and field you
+  name must exist in the source — grep before you write it. "I'm pretty sure
+  that's the name" is not good enough. A wrong name is worse than no name.
+- **Walk the lifecycle by handler.** Map each step a user takes to the actual
+  instruction handler and the key accounts it touches (e.g. "Alice calls
+  `deposit_reserve_liquidity`; it moves USDC into the reserve's `liquidity_vault`
+  and mints her share tokens"). Plain-English mechanics with no handler names
+  leave the reader unable to connect the story to the program.
+- **Get the account hierarchy right.** Spell out what owns what (market →
+  reserves → vault + share mint; obligations; per-obligation collateral vaults)
+  rather than hand-waving "the program stores it."
+
+## Use the right words
+
+- **Solana terminology, not Ethereum.** "Programs" not "smart contracts",
+  "transaction fees" not "gas". No mempools. Don't explain Solana by analogy to
+  chains the reader may not care about.
+- **Cut needless jargon.** If a plain phrase works, use it. Drop terms like
+  "money market" or "loan officer" when "lenders earn yield, borrowers borrow
+  against assets" says it more clearly.
+- **One name per role, enforced throughout.** Pick a single term for each party
+  (lender/borrower/liquidator/owner) and never switch mid-explanation.
+- **Describe what is, not what was.** Document current behavior, not history. No
+  "no longer uses X" or "previously did Y" in a summary.
+
+## Explain through people and motivations
+
+- **Give each actor a name and a concrete reason to act.** "Alice wants yield on
+  idle USDC"; "Bob won't sell his SpaceX, so he borrows against it"; "Dave
+  liquidates for the discount." Personas make a protocol legible.
+- **Every actor needs a motivation — including the operator.** If the party who
+  runs the protocol has no way to make money, the economic model is incomplete;
+  say how they earn (e.g. the reserve-factor spread) or flag that they don't.
+- **Show opposing cases when the program is symmetric.** A long that wins and a
+  short that gets liquidated teaches more than one happy path.
+
+## Be honest about mechanism and incentives
+
+- **Explain incentives correctly, and correct common misconceptions.** Don't let
+  a plausible-but-wrong mental model stand. Example: liquidation is not a "crank
+  fee" — the liquidator is a principal who repays debt from their own pocket and
+  takes the borrower's collateral at a discount; the program can't sell
+  collateral itself, so it pays outsiders to show up.
+- **Contrast onchain vs offchain on what actually differs:** collateral instead
+  of credit, rules-as-deployed-bytecode, algorithmic (utilization-based) rates,
+  permissionless liquidation, oracle dependence, and the finality of bugs.
+
+## Numbers and external facts
+
+- **Real, current, cited — or clearly hypothetical.** If you cite a token or a
+  price, verify it's real and current and cite the source. Mark any invented or
+  future figure as illustrative; never present it as fact.
+- **Keep token math concrete.** Use base units, decimals, and a worked example
+  ("100 SPCXx at $170 = $17,000 collateral; 75% LTV ⇒ borrow up to $12,750")
+  rather than vague proportions.
+
+## Name peers, kept current
+
+- Reference real comparable programs (e.g. Kamino Lend, MarginFi, Save) and use
+  **current** names (Save, not Solend). Don't cite dead, hacked, or irrelevant
+  projects, and don't reach to other ecosystems for the comparison.
+
+## Scope, custody, and disclaimers
+
+- **State simplifications plainly.** Distinguish the example from production: a
+  test oracle vs a real Switchboard/Pyth feed, one market vs many, no fee tier,
+  no audit. Don't let a reader mistake a teaching example for production-ready.
+- **Describe custody precisely; avoid loaded words.** Don't claim "non-custodial"
+  or "trustless" loosely. Say what's true: funds sit in program-owned vault PDAs,
+  the owner can change risk params and collect fees but has no path to user
+  funds, and the deployed rules can't be bypassed.
+
+## Shape
+
+- **Lead with the outcome**, then support it. Respect a length/time budget, cut
+  anything that doesn't earn its place, and match the depth to the audience.


### PR DESCRIPTION
## What

Adds `SUMMARIZING-PROGRAMS.md` — a short guide for writing truthful, clear summaries of Solana programs (READMEs, walkthroughs, video scripts, answers). It sits alongside `SKILL.md`, `RUST.md`, and `TYPESCRIPT.md` as explanation guidance rather than coding guidance.

## Why

Came out of explaining a Kamino/Solend-style lending program end to end. Several recurring rules made the difference between a clear, accurate summary and a misleading one, so they're worth capturing.

## Contents

- **Ground everything in the code** — name only real handlers/accounts/fields (grep first), walk the lifecycle by handler, get the account hierarchy right.
- **Use the right words** — Solana-not-Ethereum terminology, cut needless jargon, one name per role, describe what *is* not what *was*.
- **Explain through people and motivations** — named personas with concrete motives; every actor needs one, including the operator; show opposing cases when the program is symmetric.
- **Be honest about mechanism and incentives** — correct common misconceptions (e.g. liquidation is a principal buying discounted collateral, not a crank fee); contrast onchain vs offchain on what actually differs.
- **Numbers and external facts** — real/current/cited, or clearly hypothetical; concrete base-unit math.
- **Name peers, kept current** — Kamino/MarginFi/Save, current names, no dead/hacked/other-chain comparisons.
- **Scope, custody, disclaimers** — state simplifications; describe custody precisely; avoid loose "non-custodial"/"trustless" claims.
- **Shape** — lead with the outcome, respect the length budget, match the audience.

https://claude.ai/code/session_01RwE8f8ahP5S6SDNTsXmpj9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwE8f8ahP5S6SDNTsXmpj9)_