### PR TITLE
Summarizing programs: add step-by-step state-transition ledger guidance

### DIFF
--- a/skills/solana/SKILL.md
+++ b/skills/solana/SKILL.md
@@ -149,6 +149,7 @@ These apply to READMEs, docs, blog posts, and PR descriptions for finance-relate
 - **Be careful with the word "securities".** It's a legal term. SOL is not a security. Asset-leasing is not "securities lending" even when the mechanics are analogous. Prefer "asset lending", "token lending", or "directional token lending" — and ask before picking one.
 - **Spell out two-asset flows with concrete examples.** "Posts collateral and takes delivery of borrowed tokens" reads circular. "Posts USDC as collateral, borrows NVDAx" makes the asymmetry obvious. Don't make the reader infer that mints A and B are different things.
 - **Name the instruction handlers in lifecycle prose.** When walking through "what the user does" (open position, close position, liquidate), name the actual handler (`take_lease`, `return_lease`, `liquidate`). Plain-English mechanics without handler names leave the reader unable to connect the narrative to the code.
+- **When you explain or summarize a program** — a README, walkthrough, video script, or answer — follow [SUMMARIZING-PROGRAMS.md](SUMMARIZING-PROGRAMS.md): persona-driven casts, real assets, correct incentives, and step-by-step account state-transition + token-movement ledgers.
 
 ## General Coding Guidelines
 

--- a/skills/solana/SUMMARIZING-PROGRAMS.md
+++ b/skills/solana/SUMMARIZING-PROGRAMS.md
@@ -56,6 +56,71 @@ explanation-specific guidance not covered there.
   vault + share mint; obligations; per-obligation collateral vaults) rather than
   hand-waving "the program stores it."
 
+## Show the state changes, step by step
+
+A walkthrough is only legible if the reader can see what each call *does* to
+onchain state. Render the program as a ledger, one instruction at a time.
+
+- **Go call by call, in the order a real user invokes them, across the whole
+  lifecycle.** Create → register → act → match → cancel → settle → withdraw.
+  One instruction per step; don't skip the unglamorous setup or the closing
+  settle/withdraw — those are where custody and incentives become real.
+- **For each step, list the accounts it touches as `ADDED` (created here) or
+  `UPDATED` (mutated here); for `UPDATED`, show only the fields that change, as
+  `before → after`.** Don't reprint unchanged state — the diff is the point.
+- **Label every account's address model and authority.** Mark it *off curve* (a
+  PDA — list its seeds) or *on curve* (a plain keypair, client-generated), and
+  name who signs for it. This is what makes custody legible: a vault keypair
+  whose authority is a market PDA, or an order book held as a client keypair
+  rather than a PDA, each tell the reader who can move what.
+- **End every step with an explicit token-movement block** — `FROM → TO`,
+  amount, and the reason (collateral lock, fee sweep, settlement payout). When
+  nothing moves, write `none` and say why. Readers assume a match pays out;
+  show them when it doesn't.
+- **Separate accounting from custody.** A match or fill usually moves *numbers*
+  — credited/owed (unsettled) balances — while the tokens stay in the vaults
+  until a later settle. State plainly where value is *owed* versus where it has
+  actually *moved*; conflating the two is the most common way a walkthrough lies.
+- **Annotate the fee on every step, including the ones that generate none.**
+  Show the arithmetic by hand (e.g. `250 × 3 = 750; 750 × 25 bps ÷ 10,000 =
+  1.875 → 1`) and state the rounding direction, deferring to *Onchain Financial
+  Math → round in the protocol's favour* in [RUST.md](RUST.md). "Fee generated:
+  none — nothing filled" on a resting order is as informative as the one line
+  where a fee is born.
+- **Explain each non-obvious design decision the moment it first bites, in a
+  sentence or two — not in a separate architecture dump.** Why an order book is
+  a client keypair, not a PDA (it can be ~180 KB; a program can't allocate
+  something that large inside a transaction, so the client creates it and the
+  program verifies it is empty and program-owned); why a resting maker sets the
+  fill price (the taker gets price improvement); why N fills sweep one fee
+  transfer, not N.
+- **Keep numbers small and hand-verifiable, and reconcile at the end.** Use
+  quantities a reader can multiply in their head, so they can check each vault
+  balance and confirm tokens-in == tokens-out — the same conservation check
+  [RUST.md](RUST.md) requires of the program itself (*Assert token
+  conservation*).
+
+A single step in this format:
+
+```
+### Carol asks to sell 3 NVDAx at 245 — and matches Bob's resting 250 bid
+
+ADDED — Order #3 (Carol)   [off curve — PDA, seeds: "order" + market + order_id]
+    side: ask   price: 245 (her limit, NOT the 250 fill)   qty: 3   status: Filled
+
+UPDATED — fee_vault        [on curve — keypair; authority = Market PDA]
+    balance: 0 → 1 USDC                 ← the fee is born here
+
+UPDATED — Bob MarketUser   [off curve — PDA]
+    unsettled_base: 0 → 3               (owed to Bob, not yet paid out)
+
+TOKEN MOVEMENT:
+    Carol base ATA → base_vault   3 NVDAx   (taker collateral lock)
+    quote_vault    → fee_vault    1 USDC    (one sweep after all fills)
+
+Fee generated: 1 USDC  (250 × 3 = 750; 750 × 25 bps ÷ 10,000 = 1.875 → 1, rounded down)
+```
+
 ## Name peers, kept current
 
 Reference real comparable programs (e.g. **Kamino Lend**, **MarginFi**, **Save**)


### PR DESCRIPTION
## What & why

`SUMMARIZING-PROGRAMS.md` already covers personas, real assets, incentives, peers, and pushing back on incomplete programs. Reviewing it against a real artifact — an order-book walkthrough video script — surfaced one major pattern it doesn't yet capture: **how to render a program's behaviour as a step-by-step state-transition ledger.** That format is what makes a walkthrough *verifiable* rather than hand-wavy, and it's the most common place explanations quietly lie (e.g. implying a match pays out when it only credits an owed balance).

## Changes

**1. New section — "Show the state changes, step by step"** (the headline). Distilled from the script's structure, it says to:
- Go **call by call, in invocation order, across the whole lifecycle** (create → register → act → match → cancel → settle → withdraw) — including the unglamorous setup and closing steps, where custody and incentives become real.
- Render each step as **`ADDED`/`UPDATED` account diffs** showing only changed fields as `before → after`.
- **Label each account on-/off-curve** (PDA + seeds vs client keypair) **and its authority**, so custody is legible.
- End each step with an **explicit token-movement block** (`FROM → TO`, amount, reason), and write `none` + why when nothing moves.
- **Separate accounting from custody** — owed/unsettled balances vs tokens that actually moved at settle.
- **Annotate the fee on every step, including the no-fee ones**, with hand-worked arithmetic and rounding direction (defers to `RUST.md` *round in the protocol's favour*).
- **Explain non-obvious design decisions inline** at the moment they bite (e.g. why the order book is a ~180 KB client keypair, not a PDA; why the resting maker sets the fill price → price improvement; why N fills sweep one fee transfer).
- **Keep numbers hand-verifiable and reconcile** via token conservation (defers to `RUST.md` *Assert token conservation*).

It includes a compact worked example of the ledger format. Per this file's convention (trimmed to net-new rules), shared rules aren't restated — they're referenced by section name in `SKILL.md`/`RUST.md`.

**2. Fixes an orphaned skill doc** (incidental but directly in scope). When the skill moved into `skills/solana/` (PR #26), `SUMMARIZING-PROGRAMS.md` was left at the repo root — so its `[SKILL.md]`/`[RUST.md]` sibling links were **broken**, and `SKILL.md` never referenced it, so it wasn't part of the loaded skill. This PR:
- `git mv`s it into `skills/solana/` alongside the other reference files (links now resolve, and it's part of the skill bundle).
- Adds a reference from `SKILL.md` → *Writing About Financial Software* so it's discoverable.

## Verification
- `claude plugin validate .` passes.
- All relative links in `SUMMARIZING-PROGRAMS.md` (`SKILL.md`, `RUST.md`) and the new `SKILL.md → SUMMARIZING-PROGRAMS.md` link resolve to existing sibling files; no stray root copy remains.

https://claude.ai/code/session_012LzSMSq6U49UoXUEPgWkjV

---
_Generated by [Claude Code](https://claude.ai/code/session_012LzSMSq6U49UoXUEPgWkjV)_