### PR TITLE
Onchain Financial Math: add Compound interest guidance

### DIFF
--- a/skills/solana/RUST.md
+++ b/skills/solana/RUST.md
@@ -59,6 +59,43 @@ Applies to any code touching money, balances, prices, shares, fees, or token amo
 - **Oracle freshness uses slots, not unix time.** Slot count is what the runtime guarantees; `Clock::get()?.unix_timestamp` is validator-influenced. Check `last_updated_slot` against `Clock::get()?.slot` and reject if older than N slots. If you must use a unix timestamp (because the oracle only exposes one), state why in a comment.
 - **Canonical pubkey ordering for two-asset pools.** Order mints so `mint_a.key() < mint_b.key()` (lexicographic on the 32-byte key). Same pool whether the user passes `(USDC, SOL)` or `(SOL, USDC)`. Enforce in the constraint, don't rely on the client.
 
+### Compound interest
+
+For interest, fees that roll up, or any "grows by a rate each period" quantity. The same integer-fixed-point discipline above applies; these rules are specific to the compounding.
+
+- **Compute `(1 + r)^n` by exponentiation-by-squaring on a scaled integer — never `powf`, `exp`, or anything touching `e`.** `e` and `powf` are floats: non-deterministic and banned by the integers-only rule above. Hold `1.0` as a WAD-scaled integer (`ONE_WAD = 1_000_000_000_000_000_000` = 1e18, in `u128`), form the per-period factor `(1 + rate_per_period)` in the same scale, and raise it to the integer power of periods elapsed with square-and-multiply. This is exactly what the SPL token-lending lineage ships (Save/Solend, Port: `(1 + rate/SLOTS_PER_YEAR).pow(slots_elapsed)`), and it is *exact* discrete compounding up to one truncation per multiply — error `O(log n)` ULPs, far below token granularity.
+
+```rust
+// 1.0 in WAD fixed point. factor and result are u128 in this scale.
+const ONE_WAD: u128 = 1_000_000_000_000_000_000;
+
+// Multiply two WAD-scaled values, rescaling back down. Floors (truncates).
+// Use a wider intermediate (U192/U256) if either operand can exceed ~1e19.
+fn wad_mul(a: u128, b: u128) -> Option<u128> {
+    a.checked_mul(b)?.checked_div(ONE_WAD) // multiply before divide
+}
+
+// (1 + rate_per_period)^periods, exact discrete compounding, O(log n) muls.
+fn compound_factor(mut factor: u128, mut periods: u64) -> Option<u128> {
+    let mut result = ONE_WAD; // 1.0
+    while periods > 0 {
+        if periods & 1 == 1 {
+            result = wad_mul(result, factor)?;
+        }
+        factor = wad_mul(factor, factor)?;
+        periods >>= 1;
+    }
+    Some(result)
+}
+```
+
+- **Compound per slot, not per unix second.** Periods are slots elapsed (`Clock::get()?.slot - last_update_slot`), and the per-period rate is `annual_rate / SLOTS_PER_YEAR` — same reasoning as *Oracle freshness uses slots, not unix time*. Early-return when zero slots have elapsed.
+- **Accrue lazily into a stored cumulative index, not per position.** Keep one `cumulative_borrow_rate` (and `last_update_slot`) on the market; multiply it by the compound factor on any touch; each position's owed amount is a ratio of indices. This is the universal Solana pattern (Save, Port, Kamino) — it makes accrual permissionless and O(1) per user.
+- **Round the *result* against the user, and decide direction explicitly.** Interest owed **by** a user (borrow, fee) rounds **up** (`ceiling`); interest credited **to** a user (supply yield) rounds **down** (`floor`) — per *Round in the protocol's favour*. The factor's per-multiply truncation is negligible; the load-bearing rounding is converting the index to a token amount, so apply `floor`/`ceil` there. Rounding the wrong way here is the exact bug class behind the SPL token-lending disclosure (round-trip extraction; the fix replaced `round` with `floor`) — a rounding-in-the-user's-favour error is a drain, not a cosmetic.
+- **`spl-math`'s `PreciseNumber` is a correct *reference* for the algorithm, but don't depend on it.** Its `checked_pow` is a clean square-and-multiply and the crate has no `unsafe`. However: `solana-program-library` was archived (read-only) in 2025 and the crate is unmaintained; `PreciseNumber` rounds **half-up** (it adds `ONE/2` before dividing), which can round *in the user's favour* — wrong for money; and it is CU-heavy (U256 internals). If you want its math, vendor the ~15-line square-and-multiply (it's Apache-2.0) into your own WAD helpers and control the rounding yourself, rather than taking a dependency on an abandoned crate whose default rounding you have to fight.
+- **A truncated binomial/Taylor series is an acceptable *compute* optimisation, not a default.** For large slot gaps, exact `pow` is `O(log n)` full-width multiplies; Aave and Kamino instead expand `(1 + b)^n ≈ 1 + nb + n(n-1)/2·b² + n(n-1)(n-2)/6·b³`, which is `O(1)` and accurate because the per-slot rate `b` is microscopic (so `b⁴+` vanishes). If you do this, keep the same scaled-integer/checked discipline and ensure the truncation error rounds *against* the user (Aave's comment notes it deliberately undercharges borrowers / underpays suppliers).
+- **If you accrue simple interest per touch and call it "compound", say so.** Multiplying principal by `(1 + r·Δt)` once per interaction (marginfi, Compound v2) only compounds *across* settlement events; over a long un-touched gap it under-accrues versus true `(1+r)^n`. That's a legitimate design, but document it as simple-per-accrual — don't claim exact compounding the code doesn't do (*Fight for Truth*).
+
 ### Escrows, Vaults, and Escape Hatches
 
 - **Every vault stores who may withdraw, and every withdraw verifies it.** A vault whose PDA signs for any caller is an open drain: if the only signer in the withdraw instruction is the fee payer and the recipient is client-supplied, anyone can withdraw anything. Record the depositor/authority when assets enter, `require!` it (against a `Signer`) when they leave. "The README admits there is no authority" does not make the program acceptable as a reference.


### PR DESCRIPTION
## What

Adds a **`### Compound interest`** subsection to `RUST.md`'s *Onchain Financial Math* section. It recommends one approach as the safest + most accurate, and justifies it from production source and audit history below.

## The recommendation, and why it's the safest and most accurate

**Discrete compounding via exponentiation-by-squaring on a WAD-scaled integer, accrued per slot into a cumulative index, with the result rounded explicitly against the user.**

**1. Integer fixed-point, never floats / `e` / `powf`.** Floats are non-deterministic across validators (a consensus hazard) and every protocol examined avoids them. `e^(rt)` and `powf` are float operations. The whole skill already mandates integers; this just names the trap for interest specifically.
- marginfi (`I80F48`), Kamino (`U68F60`), Save/Solend & Port (`Decimal`/`Rate` @ WAD `1e18`) — all integer fixed-point, no floats. Helius explicitly warns "`e` is a float! Avoid using floats for interest calculations." ([helius.dev/blog/solana-arithmetic](https://www.helius.dev/blog/solana-arithmetic))

**2. Exponentiation-by-squaring is exact and cheap for integer periods.** `(1+r)^n` by square-and-multiply is the exact power (not an approximation) over integer `n`, in `O(log n)` multiplications — error is bounded by one truncation per multiply, `O(log n)` ULPs at WAD scale, far below token granularity. This is precisely what the **SPL token-lending lineage ships**:
- Save/Solend `compound_interest`: `(1 + rate/SLOTS_PER_YEAR).try_pow(slots_elapsed)`, `try_pow` = square-and-multiply. ([reserve.rs](https://github.com/solendprotocol/solana-program-library/blob/master/token-lending/program/src/state/reserve.rs))
- Port Finance: identical pattern. ([reserve.rs](https://github.com/port-finance/variable-rate-lending/blob/master/token-lending/program/src/state/reserve.rs))
- Algorithm background: exact for integer exponents, `O(log n)`. ([cp-algorithms](https://cp-algorithms.com/algebra/binary-exp.html), [Wikipedia](https://en.wikipedia.org/wiki/Exponentiation_by_squaring))

**3. Per slot, lazy cumulative index.** Periods are slots elapsed (slot count is runtime-guaranteed; unix time is validator-influenced — consistent with the skill's existing oracle-freshness rule). Accrue into one `cumulative_borrow_rate` on any touch; per-position interest is a ratio of indices → permissionless, O(1) per user. Universal across Save, Port, Kamino.

**4. Rounding direction is the load-bearing safety decision** — round the *result* against the user (owed-by-user → `ceil`, credited-to-user → `floor`). This is the exact class behind real drains:
- **Neodyme SPL token-lending disclosure: ~$2.6B at risk**, round-trip deposit/redeem extraction; **fix replaced `round` with `floor`**. ([neodyme.io](https://neodyme.io/blog/lending_disclosure))
- OtterSec SPL stable-swap: floor where ceil was needed, one token extracted per instruction; fixed with `checked_ceil_div`. ([osec.io](https://osec.io/blog/2022-04-26-spl-swap-rounding/))
- Hundred Finance (~$7.4M), Sonne (~$20M): redeem-path precision loss. ([blocksec](``https://blocksec.com/blog/6-hundred-finance-incident-catalyzing-the-wave-of-precision-related-exploits-in-vulnerable-forked-protocols``))

## The `spl-math` verdict (you asked specifically)

You were right that it has good reference code — **its `checked_pow` is a clean exponentiation-by-squaring and the crate has no `unsafe`.** But I'd push back on *depending* on it:
- **Abandoned:** `solana-labs/solana-program-library` was **archived read-only in March 2025**; `spl-math` is stuck at `0.3.0`, flagged "minimal maintenance." ([repo](https://github.com/solana-labs/solana-program-library), [crates.io](https://crates.io/crates/spl-math))
- **Wrong-way rounding for money:** `PreciseNumber` rounds **half-up** (adds `ONE/2` before dividing), so accrual can round *in the user's favour* — the opposite of what a money protocol needs. ([precise_number.rs](https://github.com/solana-labs/solana-program-library/blob/master/libraries/math/src/precise_number.rs))
- **CU-heavy:** maintainers note token-swap "can barely do a couple of calculations before maxing out" with it. ([SPL #3162](https://github.com/solana-labs/solana-program-library/issues/3162))

So the guidance says: **vendor the ~15-line square-and-multiply (Apache-2.0) into your own WAD helpers and control rounding yourself**, rather than take a dependency on an abandoned crate whose default rounding you'd have to fight. This matches the skill's existing "don't reach for a crate" stance.

## Also covered
- **Binomial/Taylor approximation** (`1 + nb + n(n-1)/2·b² + …`) as an `O(1)` *compute* optimisation for large slot gaps, accurate because per-slot `b` is microscopic — used by Aave (3rd-order, with an explicit comment that it deliberately undercharges borrowers/underpays suppliers) and Kamino. Acceptable, but make the error round against the user. ([Aave MathUtils.sol](https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/libraries/math/MathUtils.sol), [Kamino klend reserve.rs](https://github.com/Kamino-Finance/klend/blob/master/programs/klend/src/state/reserve.rs))
- **Don't call simple-per-accrual "compound"** — marginfi/Compound v2 only compound across settlement events and under-accrue over idle gaps (*Fight for Truth*). ([marginfi interest_rate.rs](https://github.com/mrgnlabs/marginfi-v2/blob/main/programs/marginfi/src/state/interest_rate.rs))

## Verification
- `claude plugin validate .` passes; code fences balanced; section renders under *Onchain Financial Math*.
- Includes a minimal, checked `wad_mul` / `compound_factor` reference (multiply-before-divide, wider-intermediate note for large operands).

https://claude.ai/code/session_012LzSMSq6U49UoXUEPgWkjV

---
_Generated by [Claude Code](https://claude.ai/code/session_012LzSMSq6U49UoXUEPgWkjV)_