### PR TITLE
skills: scenarios come from the wider economy, not crypto itself

### DIFF
--- a/skills/solana/SUMMARIZING-PROGRAMS.md
+++ b/skills/solana/SUMMARIZING-PROGRAMS.md
@@ -15,6 +15,7 @@ Rules for explaining a Solana program clearly and truthfully — in a README, a 
   - **Dave** liquidates unhealthy positions for the discount.
   - **Maria** runs the market and earns the interest spread (the reserve factor).
 - **Show opposing cases when the program is symmetric** (a long that wins and a short that gets liquidated teaches more than one happy path).
+- **Set the story in the wider economy, not in crypto itself.** The program is the rails; the scenario should be cargo a non-crypto reader recognizes. Good: raising funds to manufacture a production run of equipment, a startup raising a round, stocking inventory, earning yield on savings, staying long NVIDIA. Bad (crypto-for-crypto): raising funds to audit a Solana program, betting on token prices, funding a protocol treasury. If the scenario only makes sense to someone already deep in crypto, replace it.
 
 ## Use real, recognizable assets
 


### PR DESCRIPTION
Adds a rule to `SUMMARIZING-PROGRAMS.md` under "Explain through people and motivations": walkthrough scenarios must come from the wider economy (manufacturing a production run, a startup raising a round, stocking inventory, staying long NVIDIA), never crypto-for-crypto (raising funds to audit a Solana program, betting on token prices, funding a protocol treasury). If a scenario only makes sense to someone already deep in crypto, it gets replaced.

Motivated by a book chapter draft that cast a fundraiser as "raising USDC to audit a Solana library" — exactly the kind of example this rule prevents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjDPoqwPYDGnLoMoXsto8r

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjDPoqwPYDGnLoMoXsto8r)_