### PR TITLE
Add the marketplace manifest, and name the repository by its current name

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "quicknode",
+  "owner": {
+    "name": "Quicknode",
+    "url": "https://www.quicknode.com"
+  },
+  "plugins": [
+    {
+      "name": "solana-finance",
+      "source": "./",
+      "description": "Solana finance rules for Claude Code: Anchor, Quasar, Rust and TypeScript, with onchain math, custody, oracle freshness and slippage checks."
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "quicknode",
   "owner": {
     "name": "Quicknode",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,8 +8,8 @@
     "name": "Quicknode",
     "url": "https://www.quicknode.com"
   },
-  "homepage": "https://github.com/quicknode/solana-claude-skill",
-  "repository": "https://github.com/quicknode/solana-claude-skill",
+  "homepage": "https://github.com/quicknode/solana-finance-claude-plugin",
+  "repository": "https://github.com/quicknode/solana-finance-claude-plugin",
   "license": "MIT",
   "keywords": [
     "solana",

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can also install just the skill directly:
 npx skills add https://github.com/quicknode/solana-finance-claude-plugin
 ```
 
-This installs the skill to your Claude Code skills directory (`~/.claude/skills/`).
+This installs the skill into the current project's `.claude/skills/` directory. Add `-g` to install it for every project, under `~/.claude/skills/`, and `--agent claude-code` if the CLI detects other agents you do not want it installed for.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ This plugin has the **most stars of any ecosystem Solana Claude plugin** and is 
 
 ### As a plugin (recommended)
 
-Once the plugin is published, install it from the marketplace:
+Add this repository as a marketplace, then install the plugin from it:
 
 ```
-/plugin install solana-finance
+/plugin marketplace add quicknode/solana-finance-claude-plugin
+/plugin install solana-finance@quicknode
 ```
 
 ### As a standalone skill
@@ -32,7 +33,7 @@ Once the plugin is published, install it from the marketplace:
 You can also install just the skill directly:
 
 ```bash
-npx skills add https://github.com/quicknode/solana-finance-skill
+npx skills add https://github.com/quicknode/solana-finance-claude-plugin
 ```
 
 This installs the skill to your Claude Code skills directory (`~/.claude/skills/`).
@@ -51,6 +52,7 @@ Once installed, the skill automatically applies when Claude Code works on Solana
 
 ```
 .claude-plugin/plugin.json   # Plugin manifest (name, author, version)
+.claude-plugin/marketplace.json  # Marketplace manifest, so /plugin marketplace add accepts this repo
 skills/solana/               # The skill
   SKILL.md                   # Skill entry point + general guidelines
   ANCHOR.md  RUST.md  QUASAR.md  TYPESCRIPT.md   # Language/framework references


### PR DESCRIPTION
`/plugin marketplace add` expects `.claude-plugin/marketplace.json`, and the repository had only `plugin.json`, so the README's install step could not work.

- **`.claude-plugin/marketplace.json`** lists this repository as the one plugin in a `quicknode` marketplace, with the repository root (`./`) as its source.
- **README** now gives the two commands: `/plugin marketplace add quicknode/solana-finance-claude-plugin`, then `/plugin install solana-finance@quicknode`. The repository layout lists the new file.
- **Stale names.** `plugin.json` gave the homepage and repository as `solana-claude-skill`, and the standalone-skill install line pointed at `solana-finance-skill`. Both now say `solana-finance-claude-plugin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLVyPRAVgHdw8kLTvEN23w

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLVyPRAVgHdw8kLTvEN23w)_