### PR TITLE
Update figure scaling metrics in Solana diagrams documentation

### DIFF
--- a/skills/solana/DIAGRAMS.md
+++ b/skills/solana/DIAGRAMS.md
@@ -157,7 +157,7 @@ Draw the glyphs exactly as specified - one vocabulary book-wide, no per-figure v
 ## A figure's height follows from its aspect ratio
 
 - **Keep `viewBox` height within 1.22 times its width.** A figure is reproduced at the text width, so height is fixed by the ratio: past about 1.22 it cannot fit the text block once the caption is counted. Paged.js then breaks the page inside the figure, and one over-tall figure spread itself across a dozen pages, nine of them blank. Roughly 75 of this book's 252 pages were that failure.
-- **Shrinking to fit is not available.** At the text width the scale is 0.646pt per unit, so a 7-unit seed label already prints at 4.52pt and 59% of all figure text is under 6pt. A figure that does not fit has to carry less or rearrange, never scale down.
+- **Shrinking to fit is not available.** At the text width the scale is 0.612pt per unit, so a 7-unit seed label already prints at 4.28pt and most figure text is under 6pt. A figure that does not fit has to carry less or rearrange, never scale down.
 - **Look for the dead band before cutting content.** The vault flow figures ran an eight-box column down the right side while the middle was empty for 360 units. Moving three boxes into that space took 913 units to 716 and lost nothing.
 
 ## Numbered step labels


### PR DESCRIPTION
## Summary
Updated the technical specifications for figure scaling in the Solana diagrams documentation to reflect more accurate measurements.

## Changes
- Updated the scale conversion factor from `0.646pt per unit` to `0.612pt per unit` at text width
- Adjusted the example seed label size calculation from `4.52pt` to `4.28pt` for a 7-unit label
- Refined the description of figure text sizing from "59% of all figure text is under 6pt" to "most figure text is under 6pt" for better accuracy

## Details
These changes correct the mathematical basis for understanding how figures scale within the page layout constraints. The updated metrics provide more precise guidance for authors when determining whether figure content will fit within the 1.22 aspect ratio constraint without requiring page breaks or scaling adjustments.

https://claude.ai/code/session_01GxzC3jSKEroPPixDTnPWR4